### PR TITLE
Allow force quitting using ^C twice

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -13,6 +13,9 @@ ignore_missing_imports = True
 [mypy-scipy]
 ignore_missing_imports = True
 
+[mypy-scipy.*]
+ignore_missing_imports = True
+
 [mypy-joblib]
 ignore_missing_imports = True
 

--- a/pykoop/lmi_regressors.py
+++ b/pykoop/lmi_regressors.py
@@ -37,9 +37,14 @@ polite_stop = False
 
 def _sigint_handler(sig, frame):
     """Signal handler for ^C."""
-    print('Stop requested. Regression will terminate at next iteration...')
     global polite_stop
-    polite_stop = True
+    if not polite_stop:
+        print('Stop requested. Regression will stop safely at next iteration. '
+              'Press ^C again to force quit.')
+        polite_stop = True
+    else:
+        print('Force quitting now.')
+        exit()
 
 
 signal.signal(signal.SIGINT, _sigint_handler)


### PR DESCRIPTION
# Proposed Changes

  - Currently, `pykoop` captures ^C to allow the regression to stop safely at the next iteration. This PR allows the program to be force quit by hitting ^C twice.