### PR TITLE
Feature/add global error to predict multistep

### DIFF
--- a/.githooks/pre-commit.sh
+++ b/.githooks/pre-commit.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+# Git pre-commit hook to check staged Python files for formatting issues with
+# yapf.
+#
+# INSTALLING: Copy this script into `.git/hooks/pre-commit`, and mark it as
+# executable.
+#
+# This requires that yapf is installed and runnable in the environment running
+# the pre-commit hook.
+#
+# When running, this first checks for unstaged changes to staged files, and if
+# there are any, it will exit with an error. Files with unstaged changes will be
+# printed.
+#
+# If all staged files have no unstaged changes, it will run yapf against them,
+# leaving the formatting changes unstaged. Changed files will be printed.
+#
+# BUGS: This does not leave staged changes alone when used with the -a flag to
+# git commit, due to the fact that git stages ALL unstaged files when that flag
+# is used.
+
+# Find all staged Python files, and exit early if there aren't any.
+PYTHON_FILES=()
+while IFS=$'\n' read -r line; do PYTHON_FILES+=("$line"); done \
+  < <(git diff --name-only --cached --diff-filter=AM | grep --color=never '.py$')
+if [ ${#PYTHON_FILES[@]} -eq 0 ]; then
+  exit 0
+fi
+
+########## PIP VERSION #############
+# Verify that yapf is installed; if not, warn and exit.
+if ! command -v yapf >/dev/null; then
+  echo 'yapf not on path; can not format. Please install yapf:'
+  echo '    pip install yapf'
+  exit 2
+fi
+######### END PIP VERSION ##########
+
+########## PIPENV VERSION ##########
+# if ! pipenv run yapf --version 2>/dev/null 2>&1; then
+#   echo 'yapf not on path; can not format. Please install yapf:'
+#   echo '    pipenv install yapf'
+#   exit 2
+# fi
+###### END PIPENV VERSION ##########
+
+
+# Check for unstaged changes to files in the index.
+CHANGED_FILES=()
+while IFS=$'\n' read -r line; do CHANGED_FILES+=("$line"); done \
+  < <(git diff --name-only "${PYTHON_FILES[@]}")
+if [ ${#CHANGED_FILES[@]} -gt 0 ]; then
+  echo 'You have unstaged changes to some files in your commit; skipping '
+  echo 'auto-format. Please stage, stash, or revert these changes. You may '
+  echo 'find `git stash -k` helpful here.'
+  echo 'Files with unstaged changes:' "${CHANGED_FILES[@]}"
+  exit 1
+fi
+
+# Format all staged files, then exit with an error code if any have uncommitted
+# changes.
+echo 'Formatting staged Python files . . .'
+
+########## PIP VERSION #############
+yapf -i -r "${PYTHON_FILES[@]}"
+######### END PIP VERSION ##########
+
+########## PIPENV VERSION ##########
+# pipenv run yapf -i -r "${PYTHON_FILES[@]}"
+###### END PIPENV VERSION ##########
+
+
+CHANGED_FILES=()
+while IFS=$'\n' read -r line; do CHANGED_FILES+=("$line"); done \
+  < <(git diff --name-only "${PYTHON_FILES[@]}")
+if [ ${#CHANGED_FILES[@]} -gt 0 ]; then
+  echo 'Reformatted staged files. Please review and stage the changes.'
+  echo 'Files updated: ' "${CHANGED_FILES[@]}"
+  exit 1
+else
+  exit 0
+fi

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -1,0 +1,12 @@
+name: Check formatting
+on: [push]
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: run YAPF to test if python code is correctly formatted
+      uses: AlexanderMelde/yapf-action@master
+      with:
+        args: --verbose

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,3 @@
+[isort]
+multi_line_output=3
+include_trailing_comma = true

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,29 +1,4 @@
 [mypy]
 
 # https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
-[mypy-sklearn.*]
-ignore_missing_imports = True
-
-[mypy-abc]
-ignore_missing_imports = True
-
-[mypy-pandas]
-ignore_missing_imports = True
-
-[mypy-scipy]
-ignore_missing_imports = True
-
-[mypy-scipy.*]
-ignore_missing_imports = True
-
-[mypy-joblib]
-ignore_missing_imports = True
-
-[mypy-picos]
-ignore_missing_imports = True
-
-[mypy-optht]
-ignore_missing_imports = True
-
-[mypy-pytest]
 ignore_missing_imports = True

--- a/README.rst
+++ b/README.rst
@@ -130,6 +130,16 @@ The documentation can be compiled using
     $ cd doc
     $ make html
 
+If you want a hook to check source code formatting before allowing a commit,
+you can use
+
+.. code-block:: sh
+
+   $ cd .git/hooks/
+   $ ln -s ../../.githooks/pre-commit.sh .
+   $ chmod +x ./pre-commit.sh
+
+You will need ``yapf`` installed for this.
 
 Related packages
 ================

--- a/constraints.txt
+++ b/constraints.txt
@@ -4,6 +4,7 @@ scikit-learn>=1.0.1
 PICOS>=2.2.52
 pandas>=1.3.1
 optht>=0.2.0
+Deprecated>=1.2.13
 
 pytest
 matplotlib

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,15 +12,14 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../'))
 
+sys.path.insert(0, os.path.abspath('../'))
 
 # -- Project information -----------------------------------------------------
 
 project = 'pykoop'
 copyright = '2021, Steven Dahdah'
 author = 'Steven Dahdah'
-
 
 # -- General configuration ---------------------------------------------------
 
@@ -48,7 +47,6 @@ templates_path = ['_templates']
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
-
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -193,6 +193,9 @@ References
    Koopman realizations for the modeling and control of systems with unknown
    dynamics." arXiv:2010.09961v3 [cs.RO] (2020).
    https://arxiv.org/abs/2010.09961v3
+.. [local] Giorgos Mamakoukas, Ian Abraham, and Todd D. Murphey. "Learning
+   Stable Models for Prediction and Control." arXiv:2005.04291v2 [cs.RO]
+   (2022). https://arxiv.org/abs/2005.04291v2
 
 Citation
 ========

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -195,6 +195,7 @@ References
 .. [local] Giorgos Mamakoukas, Ian Abraham, and Todd D. Murphey. "Learning
    Stable Models for Prediction and Control." arXiv:2005.04291v2 [cs.RO]
    (2022). https://arxiv.org/abs/2005.04291v2  https://arxiv.org/abs/2010.09961v3
+.. [scorers] https://scikit-learn.org/stable/modules/model_evaluation.html
 
 Citation
 ========

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -193,9 +193,6 @@ References
    Koopman realizations for the modeling and control of systems with unknown
    dynamics." arXiv:2010.09961v3 [cs.RO] (2020).
    https://arxiv.org/abs/2010.09961v3
-.. [local] Giorgos Mamakoukas, Ian Abraham, and Todd D. Murphey. "Learning
-   Stable Models for Prediction and Control." arXiv:2005.04291v2 [cs.RO]
-   (2022). https://arxiv.org/abs/2005.04291v2
 
 Citation
 ========

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -136,6 +136,16 @@ The documentation can be compiled using
     $ cd doc
     $ make html
 
+If you want a hook to check source code formatting before allowing a commit,
+you can use
+
+.. code-block:: sh
+
+   $ cd .git/hooks/
+   $ ln -s ../../.githooks/pre-commit.sh .
+   $ chmod +x ./pre-commit.sh
+
+You will need ``yapf`` installed for this.
 
 Related packages
 ================

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -192,7 +192,9 @@ References
 .. [bilinear] Daniel Bruder, Xun Fu, and Ram Vasudevan. "Advantages of bilinear
    Koopman realizations for the modeling and control of systems with unknown
    dynamics." arXiv:2010.09961v3 [cs.RO] (2020).
-   https://arxiv.org/abs/2010.09961v3
+.. [local] Giorgos Mamakoukas, Ian Abraham, and Todd D. Murphey. "Learning
+   Stable Models for Prediction and Control." arXiv:2005.04291v2 [cs.RO]
+   (2022). https://arxiv.org/abs/2005.04291v2  https://arxiv.org/abs/2010.09961v3
 
 Citation
 ========

--- a/examples/example_pipeline_vdp.py
+++ b/examples/example_pipeline_vdp.py
@@ -1,0 +1,142 @@
+"""Example of how to use the Koopman pipeline."""
+
+import numpy as np
+from matplotlib import pyplot as plt
+
+import pykoop
+import pykoop.dynamic_models
+
+
+def main() -> None:
+    """Demonstrate how to use the Koopman pipeline."""
+    # Get sample data
+    X_vdp = pykoop.example_data_vdp()
+
+    # Create pipeline
+    kp = pykoop.KoopmanPipeline(
+        lifting_functions=[(
+            'sp',
+            pykoop.SplitPipeline(
+                lifting_functions_state=[
+                    ('pl', pykoop.PolynomialLiftingFn(order=3))
+                ],
+                lifting_functions_input=None,
+            ),
+        )],
+        regressor=pykoop.Edmd(),
+    )
+
+    # Take last episode for validation
+    X_train = X_vdp[X_vdp[:, 0] < 4]
+    X_valid = X_vdp[X_vdp[:, 0] == 4]
+
+    # Fit the pipeline
+    kp.fit(X_train, n_inputs=1, episode_feature=True)
+
+    # Extract initial conditions and input from validation episode
+    x0 = X_valid[[0], 1:3]
+    u = X_valid[:, 3:]
+
+    # Predict with re-lifting between timesteps (default)
+    X_pred_local = kp.predict_state(
+        x0,
+        u,
+        relift_state=True,
+        episode_feature=False,
+    )
+
+    # Predict without re-lifting between timesteps
+    X_pred_global = kp.predict_state(
+        x0,
+        u,
+        relift_state=False,
+        episode_feature=False,
+    )
+
+    # Plot trajectories in phase space
+    fig, ax = plt.subplots(constrained_layout=True)
+    ax.plot(
+        X_valid[:, 1],
+        X_valid[:, 2],
+        label='True trajectory',
+    )
+    ax.plot(
+        X_pred_local[:, 0],
+        X_pred_local[:, 1],
+        '--',
+        label='Local prediction',
+    )
+    ax.plot(
+        X_pred_global[:, 0],
+        X_pred_global[:, 1],
+        '--',
+        label='Global prediction',
+    )
+    ax.set_xlabel('$x_1[k]$')
+    ax.set_ylabel('$x_2[k]$')
+    ax.legend()
+    ax.grid(linestyle='--')
+
+    # Lift validation set
+    Psi_valid = kp.lift(X_valid[:, 1:], episode_feature=False)
+
+    # Predict lifted state with re-lifting between timesteps (default)
+    Psi_pred_local = kp.predict_state(
+        x0,
+        u,
+        relift_state=True,
+        return_lifted=True,
+        return_input=True,
+        episode_feature=False,
+    )
+
+    # Predict lifted state without re-lifting between timesteps
+    Psi_pred_global = kp.predict_state(
+        x0,
+        u,
+        relift_state=False,
+        return_lifted=True,
+        return_input=True,
+        episode_feature=False,
+    )
+
+    fig, ax = plt.subplots(
+        kp.n_states_out_,
+        1,
+        constrained_layout=True,
+        sharex=True,
+        squeeze=False,
+    )
+    for i in range(ax.shape[0]):
+        ax[i, 0].plot(Psi_valid[:, i], label='True trajectory')
+        ax[i, 0].plot(Psi_pred_local[:, i], '--', label='Local prediction')
+        ax[i, 0].plot(Psi_pred_global[:, i], '--', label='Global prediction')
+        ax[i, 0].grid(linestyle='--')
+        ax[i, 0].set_ylabel(rf'$\vartheta_{i + 1}[k]$')
+
+    ax[-1, 0].set_xlabel('$k$')
+    ax[0, 0].legend()
+
+    fig, ax = plt.subplots(
+        kp.n_inputs_out_,
+        1,
+        constrained_layout=True,
+        sharex=True,
+        squeeze=False,
+    )
+    for i in range(ax.shape[0]):
+        j = kp.n_states_out_ + i
+        ax[i, 0].plot(Psi_valid[:, j], label='True trajectory')
+        ax[i, 0].plot(Psi_pred_local[:, j], '--', label='Local prediction')
+        ax[i, 0].plot(Psi_pred_global[:, j], '--', label='Global prediction')
+        ax[i, 0].grid(linestyle='--')
+
+    ax[-1, 0].set_xlabel('$k$')
+    ax[0, 0].legend()
+    ax[0, 0].set_ylabel('$u[k]$')
+
+    plt.show()
+
+
+if __name__ == '__main__':
+    main()

--- a/pykoop/__init__.py
+++ b/pykoop/__init__.py
@@ -10,6 +10,7 @@ from .koopman_pipeline import (
     combine_episodes,
     extract_initial_conditions,
     extract_input,
+    score_state,
     shift_episodes,
     split_episodes,
     strip_initial_conditions,

--- a/pykoop/__init__.py
+++ b/pykoop/__init__.py
@@ -1,13 +1,31 @@
 """Koopman operator identification library in Python."""
 
-from .koopman_pipeline import (EpisodeDependentLiftingFn,
-                               EpisodeIndependentLiftingFn, KoopmanLiftingFn,
-                               KoopmanPipeline, KoopmanRegressor,
-                               SplitPipeline, combine_episodes, shift_episodes,
-                               split_episodes, strip_initial_conditions)
-from .lifting_functions import (BilinearInputLiftingFn, DelayLiftingFn,
-                                PolynomialLiftingFn, SkLearnLiftingFn)
+from .koopman_pipeline import (
+    EpisodeDependentLiftingFn,
+    EpisodeIndependentLiftingFn,
+    KoopmanLiftingFn,
+    KoopmanPipeline,
+    KoopmanRegressor,
+    SplitPipeline,
+    combine_episodes,
+    extract_initial_conditions,
+    extract_input,
+    shift_episodes,
+    split_episodes,
+    strip_initial_conditions,
+)
+from .lifting_functions import (
+    BilinearInputLiftingFn,
+    DelayLiftingFn,
+    PolynomialLiftingFn,
+    SkLearnLiftingFn,
+)
 from .regressors import Dmd, Dmdc, Edmd
 from .tsvd import Tsvd
-from .util import (AnglePreprocessor, example_data_msd, example_data_vdp,
-                   random_input, random_state)
+from .util import (
+    AnglePreprocessor,
+    example_data_msd,
+    example_data_vdp,
+    random_input,
+    random_state,
+)

--- a/pykoop/__init__.py
+++ b/pykoop/__init__.py
@@ -9,5 +9,5 @@ from .lifting_functions import (BilinearInputLiftingFn, DelayLiftingFn,
                                 PolynomialLiftingFn, SkLearnLiftingFn)
 from .regressors import Dmd, Dmdc, Edmd
 from .tsvd import Tsvd
-from .util import (AnglePreprocessor, example_data_msd, random_input,
-                   random_state)
+from .util import (AnglePreprocessor, example_data_msd, example_data_vdp,
+                   random_input, random_state)

--- a/pykoop/koopman_pipeline.py
+++ b/pykoop/koopman_pipeline.py
@@ -98,6 +98,7 @@ import numpy as np
 import pandas
 import sklearn.base
 import sklearn.metrics
+from deprecated import deprecated
 
 from ._sklearn_metaestimators import metaestimators
 
@@ -1753,6 +1754,7 @@ class KoopmanPipeline(metaestimators._BaseComposition,
         score = scorer(self, X, None)
         return score
 
+    @deprecated('Use `predict_state` instead')
     def predict_multistep(self, X: np.ndarray) -> np.ndarray:
         """Perform a multi-step prediction for the first state of each episode.
 

--- a/pykoop/koopman_pipeline.py
+++ b/pykoop/koopman_pipeline.py
@@ -1395,8 +1395,7 @@ class SplitPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
 
 class KoopmanPipeline(metaestimators._BaseComposition,
                       sklearn.base.BaseEstimator,
-                      sklearn.base.TransformerMixin,
-                      _LiftRetractMixin):
+                      sklearn.base.TransformerMixin, _LiftRetractMixin):
     """Meta-estimator for chaining lifting functions with an estimator.
 
     Attributes

--- a/pykoop/koopman_pipeline.py
+++ b/pykoop/koopman_pipeline.py
@@ -92,6 +92,7 @@ episode feature.
 """
 
 import abc
+import logging
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -101,6 +102,10 @@ import sklearn.metrics
 from deprecated import deprecated
 
 from ._sklearn_metaestimators import metaestimators
+
+# Create logger
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 
 class _LiftRetractMixin(metaclass=abc.ABCMeta):

--- a/pykoop/koopman_pipeline.py
+++ b/pykoop/koopman_pipeline.py
@@ -1753,7 +1753,9 @@ class KoopmanPipeline(metaestimators._BaseComposition,
         score = scorer(self, X, None)
         return score
 
-    def predict_multistep(self, X: np.ndarray) -> np.ndarray:
+    def predict_multistep(self,
+                          X: np.ndarray,
+                          local: bool = True) -> np.ndarray:
         """Perform a multi-step prediction for the first state of each episode.
 
         This function takes the first ``min_samples_`` states of the input,
@@ -1769,6 +1771,13 @@ class KoopmanPipeline(metaestimators._BaseComposition,
         ----------
         X : np.ndarray
             Data matrix.
+        local : bool
+            If true (default), the original state is recovered and re-lifted
+            at every timestep, before the next application of the Koopman
+            operator. If false, the Koopman operator is repeatedly applied, and
+            the original state is recovered only after the full prediction is
+            performed. These correspond to the local and global error
+            definitions of [local]_.
 
         Returns
         -------
@@ -1797,32 +1806,50 @@ class KoopmanPipeline(metaestimators._BaseComposition,
             # Extract initial state and input
             x0 = X_i[:self.min_samples_, :self.n_states_in_]
             u = X_i[:, self.n_states_in_:]
-            # Create array to hold predicted states
-            X_pred_i = np.zeros((X_i.shape[0], self.n_states_in_))
-            # Set the initial condition
-            X_pred_i[:self.min_samples_, :] = x0
-            # Predict all time steps
-            for k in range(self.min_samples_, X_i.shape[0]):
-                # Stack episode feature, previous predictions, and input
-                X_ik = combine_episodes(
-                    [(i,
-                      np.hstack((
-                          X_pred_i[(k - self.min_samples_):k, :],
-                          X_i[(k - self.min_samples_):k, self.n_states_in_:],
-                      )))],
-                    episode_feature=self.episode_feature_)
-                # Predict next step
-                try:
-                    X_pred_ik = self.predict(X_ik)[[-1], :]
-                except ValueError:
-                    crash_index = k
-                    break
-                # Extract data matrix from prediction
-                X_pred_i[[k], :] = split_episodes(
-                    X_pred_ik, episode_feature=self.episode_feature_)[0][1]
-            if crash_index is not None:
-                X_pred_i[crash_index:, :] = np.nan
-            predictions.append((i, X_pred_i))
+            if local:
+                # Create array to hold predicted states
+                X_pred_i = np.zeros((X_i.shape[0], self.n_states_in_))
+                # Set the initial condition
+                X_pred_i[:self.min_samples_, :] = x0
+                # Predict all time steps
+                for k in range(self.min_samples_, X_i.shape[0]):
+                    # Stack episode feature, previous predictions, and input
+                    window = np.s_[k - self.min_samples_:k]
+                    X_ik = combine_episodes(
+                        [(
+                            i,
+                            np.hstack((
+                                X_pred_i[window, :],
+                                X_i[window, self.n_states_in_:],
+                            )),
+                        )],
+                        episode_feature=self.episode_feature_)
+                    # Predict next step
+                    try:
+                        X_pred_ik = self.predict(X_ik)[[-1], :]
+                    except ValueError:
+                        crash_index = k
+                        break
+                    # Extract data matrix from prediction
+                    X_pred_i[[k], :] = split_episodes(
+                        X_pred_ik, episode_feature=self.episode_feature_)[0][1]
+                if crash_index is not None:
+                    X_pred_i[crash_index:, :] = np.nan
+                predictions.append((i, X_pred_i))
+            else:
+                raise NotImplementedError()  # TODO
+                # # Create array to hold predicted lifted states
+                # Xt_pred_i = np.zeros((X_i.shape[0], self.n_states_out_))
+                # # Set the initial condition
+                # xt0 = self.lift_state(x0, episode_feature=False)
+                # Xt_pred_i[:self.min_samples_, :] = xt0
+                # # Get Koopman operator
+                # U = self.regressor_.coef_.T
+                # A = U[:, :U.shape[0]]
+                # B = U[:, U.shape[0]:]
+                # # Predict all time steps
+                # for k in range(1, X_i.shape[0]):
+                #     pass
         # Combine episodes
         X_p = combine_episodes(predictions,
                                episode_feature=self.episode_feature_)

--- a/pykoop/lmi_regressors.py
+++ b/pykoop/lmi_regressors.py
@@ -339,16 +339,18 @@ class LmiEdmd(LmiRegressor):
         # Choose method to handle inverse of H
         if inv_method == 'inv':
             H_inv = picos.Constant('H^-1', _calc_Hinv(H))
-            problem.add_constraint(picos.block([
-                [Z, U],
-                [U.T, H_inv],
-            ]) >> picos_eps)
+            problem.add_constraint(
+                picos.block([
+                    [Z, U],
+                    [U.T, H_inv],
+                ]) >> picos_eps)
         elif inv_method == 'pinv':
             H_inv = picos.Constant('H^+', _calc_Hpinv(H))
-            problem.add_constraint(picos.block([
-                [Z, U],
-                [U.T, H_inv],
-            ]) >> picos_eps)
+            problem.add_constraint(
+                picos.block([
+                    [Z, U],
+                    [U.T, H_inv],
+                ]) >> picos_eps)
         elif inv_method == 'eig':
             VsqrtLmb = picos.Constant('(V Lambda^(1/2))', _calc_VsqrtLmb(H))
             problem.add_constraint(

--- a/pykoop/lmi_regressors.py
+++ b/pykoop/lmi_regressors.py
@@ -25,6 +25,7 @@ from . import koopman_pipeline, regressors, tsvd
 
 # Create logger
 log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 # Create temporary cache directory for memoized computations
 _cachedir = tempfile.TemporaryDirectory(prefix='pykoop_')

--- a/pykoop/util.py
+++ b/pykoop/util.py
@@ -289,3 +289,46 @@ def example_data_msd() -> np.ndarray:
     # Stack data and return
     X_msd = np.vstack(X_msd_lst)
     return X_msd
+
+
+def example_data_vdp() -> np.ndarray:
+    """Get example Van der Pol oscillator data.
+
+    Returns
+    -------
+    np.ndarray
+        Sample Van der Pol oscillator data.
+    """
+    # Create Van der Pol object
+    t_step = 0.01
+    vdp = dynamic_models.DiscreteVanDerPol(t_step, mu=2)
+    # Initial conditions and inputs
+    t_range = (0, 10)
+    t = np.arange(*t_range, t_step)
+    conditions = [
+        (0, np.array([1, 0]), 0.1 * np.sin(t)),
+        (1, np.array([0, 1]), 0.2 * np.cos(t)),
+        (2, np.array([-1, 0]), -0.2 * np.sin(t)),
+        (3, np.array([0, -1]), -0.1 * np.cos(t)),
+        (4, np.array([0.5, 0]), 0.1 * np.cos(t)),
+    ]
+    X_vdp_lst = []
+    # Loop over initial conditions and inputs
+    for ep, x0, u in conditions:
+        # Simulate ODE
+        t, x = vdp.simulate(
+            t_range=t_range,
+            t_step=t_step,
+            x0=vdp.x0(x0),
+            u=u,
+        )
+        # Format the data
+        X_vdp_lst.append(
+            np.hstack((
+                ep * np.ones((t.shape[0], 1)),
+                x,
+                np.reshape(u, (-1, 1)),
+            )))
+    # Stack data and return
+    X_vdp = np.vstack(X_vdp_lst)
+    return X_vdp

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ scikit-learn
 PICOS
 pandas
 optht
+Deprecated
 
 pytest
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setuptools.setup(
         'picos>=2.2.52',
         'pandas>=1.3.1',
         'optht>=0.2.0',
+        'Deprecated>=1.2.13',
     ],
     extra_require={
         'MOSEK solver': ['mosek>=9.2.49'],

--- a/tests/test_koopman_pipeline.py
+++ b/tests/test_koopman_pipeline.py
@@ -661,17 +661,15 @@ def test_strip_initial_conditons():
     np.testing.assert_allclose(X1s, X2s)
 
 
-@pytest.fixture(
-    params=[
-        pykoop.PolynomialLiftingFn(order=2),
-        pykoop.KoopmanPipeline(
-            lifting_functions=[
-                ('p', pykoop.PolynomialLiftingFn(order=2)),
-            ],
-            regressor=pykoop.Edmd(),
-        )
-    ]
-)
+@pytest.fixture(params=[
+    pykoop.PolynomialLiftingFn(order=2),
+    pykoop.KoopmanPipeline(
+        lifting_functions=[
+            ('p', pykoop.PolynomialLiftingFn(order=2)),
+        ],
+        regressor=pykoop.Edmd(),
+    )
+])
 def lift_retract_fixture(request):
     lf = request.param
     X = np.array([

--- a/tests/test_koopman_pipeline.py
+++ b/tests/test_koopman_pipeline.py
@@ -323,6 +323,192 @@ def test_combine_episodes(X, episodes, episode_feature):
     np.testing.assert_allclose(X_actual, X)
 
 
+@pytest.mark.parametrize(
+    'params',
+    [
+        {
+            'X_predicted': np.array([
+                [1, 2, 3, 4],
+                [2, 3, 3, 2],
+            ]).T,
+            'X_expected': np.array([
+                [1, 2, 3, 4],
+                [2, 3, 3, 2],
+            ]).T,
+            'n_steps': None,
+            'discount_factor': 1,
+            'regression_metric': 'neg_mean_squared_error',
+            'min_samples': 1,
+            'episode_feature': False,
+            'score_exp': 0,
+        },
+        {
+            'X_predicted': np.array([
+                [1, 2],
+                [2, 3],
+            ]).T,
+            'X_expected': np.array([
+                [1, 4],
+                [2, 2],
+            ]).T,
+            'n_steps': None,
+            'discount_factor': 1,
+            'regression_metric': 'neg_mean_squared_error',
+            'min_samples': 1,
+            'episode_feature': False,
+            'score_exp': -np.mean([2**2, 1]),
+        },
+        {
+            'X_predicted': np.array([
+                [1, 2, 3, 5],
+            ]).T,
+            'X_expected': np.array([
+                [1, 2, 3, 3],
+            ]).T,
+            'n_steps': None,
+            'discount_factor': 1,
+            'regression_metric': 'neg_mean_squared_error',
+            'multistep': True,
+            'min_samples': 1,
+            'episode_feature': False,
+            'score_exp': -np.mean([0, 0, 2**2]),
+        },
+        {
+            'X_predicted': np.array([
+                [1, 2, 3, 5],
+            ]).T,
+            'X_expected': np.array([
+                [1, 2, 3, 3],
+            ]).T,
+            'n_steps': None,
+            'discount_factor': 1,
+            'regression_metric': 'neg_mean_absolute_error',
+            'multistep': True,
+            'min_samples': 1,
+            'episode_feature': False,
+            'score_exp': -np.mean([0, 0, 2]),
+        },
+        {
+            'X_predicted': np.array([
+                [1, 2, 3, 5],
+            ]).T,
+            'X_expected': np.array([
+                [1, 2, 3, 4],
+            ]).T,
+            'n_steps': None,
+            'discount_factor': 1,
+            'regression_metric': 'neg_mean_squared_error',
+            'min_samples': 2,
+            'episode_feature': False,
+            'score_exp': -np.mean([0, 1]),
+        },
+        {
+            'X_predicted': np.array([
+                [1, 2, 3, 5],
+            ]).T,
+            'X_expected': np.array([
+                [1, 2, 3, 4],
+            ]).T,
+            'n_steps': 2,
+            'discount_factor': 1,
+            'regression_metric': 'neg_mean_squared_error',
+            'min_samples': 1,
+            'episode_feature': False,
+            'score_exp': 0,
+        },
+        {
+            'X_predicted': np.array([
+                [1, 2, 3, 5],
+            ]).T,
+            'X_expected': np.array([
+                [1, 2, 3, 4],
+            ]).T,
+            'n_steps': None,
+            'discount_factor': 0.5,
+            'regression_metric': 'neg_mean_squared_error',
+            'min_samples': 1,
+            'episode_feature': False,
+            # (0 * 1 + 0 * 0.5 + 1 * 0.25) / (1 + 0.5 + 0.25)
+            'score_exp': -0.25 / 1.75,
+        },
+        {
+            'X_predicted': np.array([
+                [0, 0, 0, 1, 1, 1],
+                [1, 2, 3, 4, 5, 6],
+            ]).T,
+            'X_expected': np.array([
+                [0, 0, 0, 1, 1, 1],
+                [1, 2, 4, 4, 6, 6],
+            ]).T,
+            'n_steps': None,
+            'discount_factor': 1,
+            'regression_metric': 'neg_mean_squared_error',
+            'min_samples': 1,
+            'episode_feature': True,
+            'score_exp': -np.mean([0, 1, 1, 0]),
+        },
+        {
+            'X_predicted': np.array([
+                [0, 0, 0, 1, 1, 1],
+                [1, 2, 3, 4, 5, 6],
+            ]).T,
+            'X_expected': np.array([
+                [0, 0, 0, 1, 1, 1],
+                [1, 2, 4, 4, 6, 6],
+            ]).T,
+            'n_steps': 1,
+            'discount_factor': 1,
+            'regression_metric': 'neg_mean_squared_error',
+            'min_samples': 1,
+            'episode_feature': True,
+            'score_exp': -np.mean([0, 1]),
+        },
+        {
+            'X_predicted': np.array([
+                [0, 0, 0, 1, 1, 1],
+                [1, 2, 3, 4, 5, 6],
+            ]).T,
+            'X_expected': np.array([
+                [0, 0, 0, 1, 1, 1],
+                [1, 2, 4, 4, 6, 6],
+            ]).T,
+            'n_steps': None,
+            'discount_factor': 0.5,
+            'regression_metric': 'neg_mean_squared_error',
+            'min_samples': 1,
+            'episode_feature': True,
+            'score_exp': -(0.5 + 1) / (1 + 0.5 + 1 + 0.5),
+        },
+        {
+            'X_predicted': np.array([
+                [0, 0, 0, 1, 1, 1],
+                [1, 2, 3, 4, 5, 6],
+            ]).T,
+            'X_expected': np.array([
+                [0, 0, 0, 1, 1, 1],
+                [1, 2, 4, 4, 6, 6],
+            ]).T,
+            'n_steps': 1,
+            'discount_factor': 0.5,
+            'regression_metric': 'neg_mean_squared_error',
+            'min_samples': 1,
+            'episode_feature': True,
+            'score_exp': -(0 + 1) / (1 + 0 + 1 + 0),
+        },
+    ])
+def test_score_state(params):
+    score = pykoop.score_state(
+        params['X_predicted'],
+        params['X_expected'],
+        params['n_steps'],
+        params['discount_factor'],
+        params['regression_metric'],
+        params['min_samples'],
+        params['episode_feature'],
+    )
+    np.testing.assert_allclose(score, params['score_exp'])
+
+
 @pytest.mark.parametrize('X, min_samples, n_inputs, episode_feature, ic_exp', [
     (
         np.array([

--- a/tests/test_koopman_pipeline.py
+++ b/tests/test_koopman_pipeline.py
@@ -613,6 +613,110 @@ test_split_lf_params = [
 ]
 
 
+@pytest.mark.parametrize('kp', [
+    pykoop.KoopmanPipeline(
+        lifting_functions=[
+            ('dl', pykoop.DelayLiftingFn(n_delays_state=1, n_delays_input=1))
+        ],
+        regressor=pykoop.Edmd(),
+    ),
+    # pykoop.KoopmanPipeline(
+    #     lifting_functions=[
+    #         ('dla', pykoop.DelayLiftingFn(n_delays_state=2, n_delays_input=2)),
+    #         ('dlb', pykoop.DelayLiftingFn(n_delays_state=2, n_delays_input=2)),
+    #     ],
+    #     regressor=pykoop.Edmd(),
+    # ),
+    # pykoop.KoopmanPipeline(
+    #     lifting_functions=[
+    #         ('dla', pykoop.DelayLiftingFn(n_delays_state=2, n_delays_input=1)),
+    #         ('ply', pykoop.PolynomialLiftingFn(order=2)),
+    #         ('dlb', pykoop.DelayLiftingFn(n_delays_state=1, n_delays_input=2)),
+    #     ],
+    #     regressor=pykoop.Edmd(),
+    # ),
+    # pykoop.KoopmanPipeline(
+    #     lifting_functions=[
+    #         (
+    #             'sp',
+    #             pykoop.SplitPipeline(
+    #                 lifting_functions_state=[
+    #                     ('pl', pykoop.PolynomialLiftingFn(order=2)),
+    #                 ],
+    #                 lifting_functions_input=None,
+    #             ),
+    #         ),
+    #         ('dl', pykoop.DelayLiftingFn(n_delays_state=2, n_delays_input=2)),
+    #     ],
+    #     regressor=pykoop.Edmd(),
+    # ),
+    # pykoop.KoopmanPipeline(
+    #     lifting_functions=[
+    #         ('dla', pykoop.DelayLiftingFn(n_delays_state=1, n_delays_input=1)),
+    #         (
+    #             'sp',
+    #             pykoop.SplitPipeline(
+    #                 lifting_functions_state=[
+    #                     ('pla', pykoop.PolynomialLiftingFn(order=2)),
+    #                     ('plb', pykoop.PolynomialLiftingFn(order=2)),
+    #                 ],
+    #                 lifting_functions_input=[
+    #                     ('plc', pykoop.PolynomialLiftingFn(order=2)),
+    #                 ],
+    #             ),
+    #         ),
+    #         ('dlb', pykoop.DelayLiftingFn(n_delays_state=1, n_delays_input=1)),
+    #     ],
+    #     regressor=pykoop.Edmd(),
+    # ),
+])
+def test_predict_state(kp):
+    # Set up problem
+    t_range = (0, 5)
+    t_step = 0.1
+    msd = pykoop.dynamic_models.MassSpringDamper(0.5, 0.7, 0.6)
+
+    def u(t):
+        return 0.1 * np.sin(t)
+
+    # Solve ODE for training data
+    x0 = np.array([0, 0])
+    t, x = msd.simulate(t_range, t_step, x0, u, rtol=1e-8, atol=1e-8)
+
+    # Compute input at every training point
+    u_sim = np.reshape(u(t), (-1, 1))
+    # Format data
+    X = np.hstack((
+        np.zeros((t.shape[0] - 1, 1)),
+        x[:-1, :],
+        u_sim[:-1, :],
+    ))
+    # Fit estimator
+    kp.fit(X, n_inputs=1, episode_feature=True)
+    n_samp = kp.min_samples_
+
+    X_sim = kp.predict_state(
+        x[:n_samp, :],
+        u_sim,
+        episode_feature=False,
+        relift_state=False,
+    )
+
+    # Predict manually
+    X_sim_exp = np.empty(x.shape)
+    X_sim_exp[:, :n_samp] = x[:, :n_samp]
+    for k in range(n_samp, t.shape[0]):
+        X = np.hstack((
+            np.zeros((n_samp, 1)),
+            X_sim_exp[(k - n_samp):k, :],
+            u_sim[(k - n_samp):k, :],
+        ))
+        Xp = kp.predict(X)
+        X_sim_exp[[k], :] = Xp[[-1], 1:]
+
+    np.testing.assert_allclose(X_sim, X_sim_exp)
+
+
 @pytest.mark.parametrize('lf, X, Xt_exp, n_inputs, episode_feature, attr_exp',
                          test_split_lf_params)
 def test_split_lifting_fn_attrs(lf, X, Xt_exp, n_inputs, episode_feature,

--- a/tests/test_koopman_pipeline.py
+++ b/tests/test_koopman_pipeline.py
@@ -620,55 +620,55 @@ test_split_lf_params = [
         ],
         regressor=pykoop.Edmd(),
     ),
-    # pykoop.KoopmanPipeline(
-    #     lifting_functions=[
-    #         ('dla', pykoop.DelayLiftingFn(n_delays_state=2, n_delays_input=2)),
-    #         ('dlb', pykoop.DelayLiftingFn(n_delays_state=2, n_delays_input=2)),
-    #     ],
-    #     regressor=pykoop.Edmd(),
-    # ),
-    # pykoop.KoopmanPipeline(
-    #     lifting_functions=[
-    #         ('dla', pykoop.DelayLiftingFn(n_delays_state=2, n_delays_input=1)),
-    #         ('ply', pykoop.PolynomialLiftingFn(order=2)),
-    #         ('dlb', pykoop.DelayLiftingFn(n_delays_state=1, n_delays_input=2)),
-    #     ],
-    #     regressor=pykoop.Edmd(),
-    # ),
-    # pykoop.KoopmanPipeline(
-    #     lifting_functions=[
-    #         (
-    #             'sp',
-    #             pykoop.SplitPipeline(
-    #                 lifting_functions_state=[
-    #                     ('pl', pykoop.PolynomialLiftingFn(order=2)),
-    #                 ],
-    #                 lifting_functions_input=None,
-    #             ),
-    #         ),
-    #         ('dl', pykoop.DelayLiftingFn(n_delays_state=2, n_delays_input=2)),
-    #     ],
-    #     regressor=pykoop.Edmd(),
-    # ),
-    # pykoop.KoopmanPipeline(
-    #     lifting_functions=[
-    #         ('dla', pykoop.DelayLiftingFn(n_delays_state=1, n_delays_input=1)),
-    #         (
-    #             'sp',
-    #             pykoop.SplitPipeline(
-    #                 lifting_functions_state=[
-    #                     ('pla', pykoop.PolynomialLiftingFn(order=2)),
-    #                     ('plb', pykoop.PolynomialLiftingFn(order=2)),
-    #                 ],
-    #                 lifting_functions_input=[
-    #                     ('plc', pykoop.PolynomialLiftingFn(order=2)),
-    #                 ],
-    #             ),
-    #         ),
-    #         ('dlb', pykoop.DelayLiftingFn(n_delays_state=1, n_delays_input=1)),
-    #     ],
-    #     regressor=pykoop.Edmd(),
-    # ),
+    pykoop.KoopmanPipeline(
+        lifting_functions=[
+            ('dla', pykoop.DelayLiftingFn(n_delays_state=2, n_delays_input=2)),
+            ('dlb', pykoop.DelayLiftingFn(n_delays_state=2, n_delays_input=2)),
+        ],
+        regressor=pykoop.Edmd(),
+    ),
+    pykoop.KoopmanPipeline(
+        lifting_functions=[
+            ('dla', pykoop.DelayLiftingFn(n_delays_state=2, n_delays_input=1)),
+            ('ply', pykoop.PolynomialLiftingFn(order=2)),
+            ('dlb', pykoop.DelayLiftingFn(n_delays_state=1, n_delays_input=2)),
+        ],
+        regressor=pykoop.Edmd(),
+    ),
+    pykoop.KoopmanPipeline(
+        lifting_functions=[
+            (
+                'sp',
+                pykoop.SplitPipeline(
+                    lifting_functions_state=[
+                        ('pl', pykoop.PolynomialLiftingFn(order=2)),
+                    ],
+                    lifting_functions_input=None,
+                ),
+            ),
+            ('dl', pykoop.DelayLiftingFn(n_delays_state=2, n_delays_input=2)),
+        ],
+        regressor=pykoop.Edmd(),
+    ),
+    pykoop.KoopmanPipeline(
+        lifting_functions=[
+            ('dla', pykoop.DelayLiftingFn(n_delays_state=1, n_delays_input=1)),
+            (
+                'sp',
+                pykoop.SplitPipeline(
+                    lifting_functions_state=[
+                        ('pla', pykoop.PolynomialLiftingFn(order=2)),
+                        ('plb', pykoop.PolynomialLiftingFn(order=2)),
+                    ],
+                    lifting_functions_input=[
+                        ('plc', pykoop.PolynomialLiftingFn(order=2)),
+                    ],
+                ),
+            ),
+            ('dlb', pykoop.DelayLiftingFn(n_delays_state=1, n_delays_input=1)),
+        ],
+        regressor=pykoop.Edmd(),
+    ),
 ])
 def test_predict_state(kp):
     # Set up problem
@@ -699,7 +699,7 @@ def test_predict_state(kp):
         x[:n_samp, :],
         u_sim,
         episode_feature=False,
-        relift_state=False,
+        relift_state=True,
     )
 
     # Predict manually

--- a/tests/test_regressors.py
+++ b/tests/test_regressors.py
@@ -10,7 +10,6 @@ import pykoop.lmi_regressors
 # TODO This file is a nightmare
 
 
-
 @pytest.fixture(
     params=[
         (pykoop.Edmd(), 'msd-no-input', 1e-5, 1e-5, 'exact'),


### PR DESCRIPTION
# Proposed Changes

  - Add global prediction in addition to local prediction
  - Fix issues with `make_scorer()`
  - Set up linting #44 
  - Add VdPO sample data
  - Disable logging by default #60 
