### PR TITLE
Rename score_state to score_trajectory

### DIFF
--- a/doc/pykoop.rst
+++ b/doc/pykoop.rst
@@ -103,7 +103,7 @@ namespace for convenience.
    pykoop.combine_episodes
    pykoop.extract_initial_conditions
    pykoop.extract_input
-   pykoop.score_state
+   pykoop.score_trajectory
    pykoop.shift_episodes
    pykoop.split_episodes
    pykoop.strip_initial_conditions

--- a/pykoop/__init__.py
+++ b/pykoop/__init__.py
@@ -10,7 +10,7 @@ from .koopman_pipeline import (
     combine_episodes,
     extract_initial_conditions,
     extract_input,
-    score_state,
+    score_trajectory,
     shift_episodes,
     split_episodes,
     strip_initial_conditions,

--- a/pykoop/koopman_pipeline.py
+++ b/pykoop/koopman_pipeline.py
@@ -2036,7 +2036,7 @@ class KoopmanPipeline(metaestimators._BaseComposition,
                     relift_state=relift_state,
                 )
                 # Score prediction
-                score = score_state(
+                score = score_trajectory(
                     X_predicted,
                     X_shifted,
                     n_steps=n_steps,
@@ -2058,7 +2058,7 @@ class KoopmanPipeline(metaestimators._BaseComposition,
                 # Perform single-step prediction
                 X_predicted = estimator.predict(X_unshifted)
                 # Score prediction
-                score = score_state(
+                score = score_trajectory(
                     X_predicted,
                     X_shifted,
                     n_steps=None,
@@ -2081,7 +2081,7 @@ class KoopmanPipeline(metaestimators._BaseComposition,
         return self
 
 
-def score_state(
+def score_trajectory(
     X_predicted: np.ndarray,
     X_expected: np.ndarray,
     n_steps: int = None,

--- a/tests/test_koopman_pipeline.py
+++ b/tests/test_koopman_pipeline.py
@@ -323,7 +323,7 @@ class TestKoopmanPipelineScore:
             ),
         ],
     )
-    def test_score_state(
+    def test_score_trajectory(
         self,
         X_predicted,
         X_expected,
@@ -334,7 +334,7 @@ class TestKoopmanPipelineScore:
         episode_feature,
         score_exp,
     ):
-        score = pykoop.score_state(
+        score = pykoop.score_trajectory(
             X_predicted,
             X_expected,
             n_steps,


### PR DESCRIPTION
# Proposed Changes

  - Rename `score_state` to `score_trajectory` to be consistent with `predict_trajectory`.
